### PR TITLE
#11 volume resize from startup script

### DIFF
--- a/labmachine/files/gce_startup.sh
+++ b/labmachine/files/gce_startup.sh
@@ -112,6 +112,7 @@ then
    then
       format_disk ${LAB_VOL}
    fi
+   resize2fs  ${DEVICE}-${LAB_VOL} | tee /dev/fd/3
    mount ${DEVICE}-${LAB_VOL} ${DEFAULT_VOL}
 fi
 check_folders


### PR DESCRIPTION
This solves #11 

Now the script does a resize everytime the server is started. The command is idempotent. so it's safe to use:

```
   resize2fs  ${DEVICE}-${LAB_VOL} 
``` 
LabMachine assumes that the use of volumes are alway of the same ext filesystem type. 